### PR TITLE
[codex] enforce owner scoping for daemon APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,12 +117,21 @@ M1 已经能：
 # 1. 编
 cargo build --release --workspace
 
-# 2. 起 daemon（绑 127.0.0.1:18789）
+# 2. 配 owner 并起 daemon（绑 127.0.0.1:18789）
+export CHARON_OWNER_USER_ID="<your NyxID user_id>"
 ./target/release/charon-daemon
 # 或 cargo run -p charon-daemon
 
 # 3. 自检
 ./target/release/charon doctor
+```
+
+不知道自己的 NyxID `user_id` 时，可以先用临时值启动 daemon，只访问 `/whoami` 拿真实值，再用真实 owner 重启：
+
+```bash
+CHARON_OWNER_USER_ID=bootstrap ./target/release/charon-daemon
+curl -H "Authorization: Bearer $(cat ~/.nyxid/access_token)" \
+  https://nyx-api.chrono-ai.fun/api/v1/proxy/s/charon-echo-poc/api/v1/whoami
 ```
 
 期望输出：
@@ -140,7 +149,7 @@ cargo build --release --workspace
 All checks passed.
 ```
 
-环境变量（都有 sensible default）：`CHARON_BIND` / `CHARON_EXPECTED_AUD` / `CHARON_NYXID_ISSUER` / `CHARON_ENDPOINT` / `CHARON_NYXID_BASE_URL` / `CHARON_DOCTOR_SLUG`。完整列表见 [`docs/05`](docs/05-poc-results-and-next-steps.md#env-控制点速查)。
+环境变量：`CHARON_OWNER_USER_ID` 必填；`CHARON_BIND` / `CHARON_EXPECTED_AUD` / `CHARON_NYXID_ISSUER` / `CHARON_ENDPOINT` / `CHARON_NYXID_BASE_URL` / `CHARON_DOCTOR_SLUG` 有默认值。完整列表见 [`docs/05`](docs/05-poc-results-and-next-steps.md#env-控制点速查)。
 
 ## 仓库布局
 

--- a/crates/charon-cli/src/main.rs
+++ b/crates/charon-cli/src/main.rs
@@ -82,6 +82,8 @@ enum DaemonCmd {
         expected_aud: String,
         #[arg(long, env = "CHARON_NYXID_ISSUER", default_value = DEFAULT_NYXID_ISSUER)]
         nyxid_issuer: String,
+        #[arg(long, env = "CHARON_OWNER_USER_ID")]
+        owner_user_id: String,
         /// Daemon state dir (workspaces.json, worktrees/, …). Defaults to ~/.charon.
         #[arg(long, env = "CHARON_HOME")]
         home: Option<PathBuf>,
@@ -104,9 +106,10 @@ async fn main() -> Result<()> {
                     bind,
                     expected_aud,
                     nyxid_issuer,
+                    owner_user_id,
                     home,
                 },
-        } => start_daemon(bind, expected_aud, nyxid_issuer, home).await,
+        } => start_daemon(bind, expected_aud, nyxid_issuer, owner_user_id, home).await,
         Cmd::Daemon {
             sub: DaemonCmd::Status { endpoint },
         } => status(&endpoint).await,
@@ -130,6 +133,7 @@ async fn start_daemon(
     bind: String,
     expected_aud: String,
     nyxid_issuer: String,
+    owner_user_id: String,
     home: Option<PathBuf>,
 ) -> Result<()> {
     let home = match home {
@@ -142,6 +146,7 @@ async fn start_daemon(
             .with_context(|| format!("invalid bind {bind}"))?,
         expected_aud,
         nyxid_issuer,
+        owner_user_id,
         home,
     };
     let shutdown = CancellationToken::new();

--- a/crates/charon-daemon/src/lib.rs
+++ b/crates/charon-daemon/src/lib.rs
@@ -30,7 +30,7 @@ use tokio_util::sync::CancellationToken;
 use tower_http::trace::TraceLayer;
 use tracing::info;
 
-use crate::nyxid_jwt::{IdentityToken, JwksClient};
+use crate::nyxid_jwt::{IdentityToken, JwksClient, OwnerAuthorizer, OwnerIdentity};
 use crate::terminal::TerminalManager;
 use crate::workspace::WorkspaceManager;
 
@@ -47,6 +47,7 @@ pub struct DaemonConfig {
     pub bind: SocketAddr,
     pub expected_aud: String,
     pub nyxid_issuer: String,
+    pub owner_user_id: String,
     pub home: PathBuf,
 }
 
@@ -60,6 +61,12 @@ impl DaemonConfig {
             .unwrap_or_else(|_| DEFAULT_EXPECTED_AUD.to_string());
         let nyxid_issuer = std::env::var("CHARON_NYXID_ISSUER")
             .unwrap_or_else(|_| DEFAULT_NYXID_ISSUER.to_string());
+        let owner_user_id = std::env::var("CHARON_OWNER_USER_ID")
+            .context("CHARON_OWNER_USER_ID env var not set")?;
+        let owner_user_id = owner_user_id.trim().to_string();
+        if owner_user_id.is_empty() {
+            anyhow::bail!("CHARON_OWNER_USER_ID must not be empty");
+        }
         let home = match std::env::var_os("CHARON_HOME") {
             Some(p) => PathBuf::from(p),
             None => default_home()?,
@@ -68,6 +75,7 @@ impl DaemonConfig {
             bind,
             expected_aud,
             nyxid_issuer,
+            owner_user_id,
             home,
         })
     }
@@ -81,6 +89,7 @@ pub fn default_home() -> Result<PathBuf> {
 #[derive(Clone, FromRef)]
 pub struct AppState {
     pub jwks: Arc<JwksClient>,
+    pub owner: Arc<OwnerAuthorizer>,
     pub workspaces: Arc<WorkspaceManager>,
     pub terminals: Arc<TerminalManager>,
 }
@@ -140,9 +149,13 @@ pub async fn serve(config: DaemonConfig, shutdown: Option<CancellationToken>) ->
             .await
             .context("initialize WorkspaceManager")?,
     );
+    let owner = Arc::new(
+        OwnerAuthorizer::new(config.owner_user_id.clone()).context("initialize OwnerAuthorizer")?,
+    );
     let terminals = Arc::new(TerminalManager::new());
     let state = AppState {
         jwks,
+        owner,
         workspaces,
         terminals,
     };
@@ -156,6 +169,7 @@ pub async fn serve(config: DaemonConfig, shutdown: Option<CancellationToken>) ->
         version = DAEMON_VERSION,
         issuer = %config.nyxid_issuer,
         expected_aud = %config.expected_aud,
+        owner_user_id = %config.owner_user_id,
         home = %config.home.display(),
         "charon-daemon listening"
     );
@@ -190,7 +204,7 @@ async fn whoami_handler(IdentityToken(identity): IdentityToken) -> Json<WhoAmIRe
 
 async fn create_workspace_handler(
     State(workspaces): State<Arc<WorkspaceManager>>,
-    IdentityToken(_identity): IdentityToken,
+    OwnerIdentity(_owner): OwnerIdentity,
     Json(req): Json<CreateWorkspaceRequest>,
 ) -> Result<(StatusCode, Json<Workspace>), (StatusCode, Json<ErrorBody>)> {
     workspaces
@@ -208,7 +222,7 @@ struct ListQuery {
 
 async fn list_workspaces_handler(
     State(workspaces): State<Arc<WorkspaceManager>>,
-    IdentityToken(_identity): IdentityToken,
+    OwnerIdentity(_owner): OwnerIdentity,
     Query(q): Query<ListQuery>,
 ) -> Json<ListWorkspacesResponse> {
     Json(ListWorkspacesResponse {
@@ -218,7 +232,7 @@ async fn list_workspaces_handler(
 
 async fn get_workspace_handler(
     State(workspaces): State<Arc<WorkspaceManager>>,
-    IdentityToken(_identity): IdentityToken,
+    OwnerIdentity(_owner): OwnerIdentity,
     Path(id): Path<String>,
 ) -> Result<Json<Workspace>, (StatusCode, Json<ErrorBody>)> {
     workspaces.get(&id).await.map(Json).ok_or_else(|| {
@@ -232,7 +246,7 @@ async fn get_workspace_handler(
 
 async fn archive_workspace_handler(
     State(workspaces): State<Arc<WorkspaceManager>>,
-    IdentityToken(_identity): IdentityToken,
+    OwnerIdentity(_owner): OwnerIdentity,
     Path(id): Path<String>,
 ) -> Result<Json<Workspace>, (StatusCode, Json<ErrorBody>)> {
     workspaces
@@ -274,7 +288,7 @@ async fn fetch_workspace_or_404(
 
 async fn tree_handler(
     State(workspaces): State<Arc<WorkspaceManager>>,
-    IdentityToken(_identity): IdentityToken,
+    OwnerIdentity(_owner): OwnerIdentity,
     Path(id): Path<String>,
     Query(q): Query<TreeQuery>,
 ) -> Result<Json<FileTreeResponse>, (StatusCode, Json<ErrorBody>)> {
@@ -287,7 +301,7 @@ async fn tree_handler(
 
 async fn file_read_handler(
     State(workspaces): State<Arc<WorkspaceManager>>,
-    IdentityToken(_identity): IdentityToken,
+    OwnerIdentity(_owner): OwnerIdentity,
     Path(id): Path<String>,
     Query(q): Query<FileQuery>,
 ) -> Result<Json<FileContent>, (StatusCode, Json<ErrorBody>)> {
@@ -300,7 +314,7 @@ async fn file_read_handler(
 
 async fn file_write_handler(
     State(workspaces): State<Arc<WorkspaceManager>>,
-    IdentityToken(_identity): IdentityToken,
+    OwnerIdentity(_owner): OwnerIdentity,
     Path(id): Path<String>,
     Query(q): Query<FileQuery>,
     Json(body): Json<WriteFileRequest>,
@@ -314,7 +328,7 @@ async fn file_write_handler(
 
 async fn diff_handler(
     State(workspaces): State<Arc<WorkspaceManager>>,
-    IdentityToken(_identity): IdentityToken,
+    OwnerIdentity(_owner): OwnerIdentity,
     Path(id): Path<String>,
 ) -> Result<Json<DiffResponse>, (StatusCode, Json<ErrorBody>)> {
     let ws = fetch_workspace_or_404(&workspaces, &id).await?;
@@ -329,11 +343,110 @@ mod tests {
     use super::*;
     use axum::body::to_bytes;
     use axum::http::Request;
+    use charon_core::IDENTITY_TOKEN_HEADER;
+    use chrono::Utc;
+    use jsonwebtoken::{Algorithm, DecodingKey, EncodingKey, Header, encode};
+    use serde_json::json;
     use tower::ServiceExt;
+
+    const TEST_ISSUER: &str = "https://issuer.test";
+    const TEST_AUD: &str = "http://localhost:18789";
+    const TEST_KID: &str = "owner-test-key";
+    // Throwaway keypair used only for route-level JWT tests.
+    const TEST_PRIVATE_KEY: &str = r#"-----BEGIN PRIVATE KEY-----
+MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCUCp7gm330NPzi
+7nogF8C5mGs0N0oIe8ec3aj+EQsG7TP/bBu3dpior8WJkq9uZcvmt/0z/quqgyqH
+2ktzMAxc9rpOIpI3mMng4Mj9ktC+zPkUo+tZZPraBYz8XuOZaPiSlwbExZ+2M3M3
+8KLg0rob61woGnwsAewlDqLjeFaWZmcVRIx+RUf7Tbk6wWM2FZ6UoBf1sCjtqlvg
+i2qNOktjFLRwytWL+nBpEAyl4by6rthIMhK8beK43Ps4A6m24noZcQ+AYenOHIV4
+dRCApiLs3019VNFOsVljnyHFnGHjW3kt8vPGbq1SS+oOp8h0SloVYK1qJxMH/6AB
+uuFDZCBFAgMBAAECggEAD5BWR7LROR1hANKlkD4vCtQVYTX22JF62OkM3TkZea7y
+aoYJG+6h+goQsHf1bZvSJf1t50t87L5BeGrgx8ljY1qlF5XW3XV4s+Wt+8q1m3md
+LihVk95j6QvwWI/5SaWZjH/IPGOyeMtL77OizBQbcNf7plOyfkXtd6/kPBnosIMG
+kq5b3Tm/23PcnNIWeI+QWFoGxuKHAIiq/axpTpwmwJwGob8A2kxnueyKO+cdqBfR
+jAWAyol2086HNMBeBeOHck+9k02wUq4kXbfCxHiNrcshb9wBLGR9AIiAAZ1wAIvW
+hm6VIutFQYtgmiLA9mDbmO/bDKDabcCvqZNxpqwCOQKBgQDM3ohKPdNAj9KAx+U6
+Q/tsyyu/GonV9pl9gxKY/rbbnVh1yvmlwYLGFXwCxUlHu1JVU1GoX75CIFdCmVAr
+VPQ/BEgJ+fb1AokFEEfja9tsr+RvhBZ4LzgsmB9qkcqjQWlP6i3K+/o4jCx7x1xN
+EFOf6itP0fYzQvux3JojyqCgVwKBgQC4/UI4dUtr6twxgy6ryFamTyAce2OicCFP
+FOSIUqOjBLjHwl2vjoa/3UQTE0ytNKlcsUoOERpJYdqL1mApqLDf+9m8g2X9xelK
+nHyFk5dIivna9uLoYQchdjV1lPbD+8sbuuxWSZXQqnSo2nQp1GcC7S3vX7fudehO
+9kVnam8ywwKBgBoTwVlh4T/4jpzh1OXDvX8tpVXf9OeNSiBVzMo4seHmd1oXCgv1
+Q8Ye+fgIULmWuHYv8tbxyO/12eWaSkAZwjU7QEg0zyCEwBgq6FukYPvGr9caAxot
+OINEocsY36hELTmE32tVA5arEQZ4a+FLULmsPvMcELCZuBv9rokbw7JlAoGAD0yC
+qYCp2Cb4Ru/+cB6FbAOnODPMLabwWkX0EIIlHlpJndupO9ehtURrWNiDwt9UEmJn
+KXqoneEF3gLAuTFGT3/YpgqH6NDxVkZS1gk6vbkgqMc6RNWhbVcFXNARCGxOg+CV
+ox060qMGOuC2Mq9qRYewANf9si72I3Gik8bto1kCgYBNVsMZ3QBrPePZiXd1NW2J
+sGLn8+lOJN6nHCQZxZpo2swcpldWDvrqFHHxm7XNBFvsJXkBd4KZnJtRPBL3yiMJ
+6M9Aicg9CMlnhZ0Gt31T7pA+IkveJrBG/psN5YwOTVKtrmx+NIKy6qD/ob0AF4XU
+CWIxQNx1v9uhuNNSXp3lzA==
+-----END PRIVATE KEY-----"#;
+    const TEST_PUBLIC_KEY: &str = r#"-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAlAqe4Jt99DT84u56IBfA
+uZhrNDdKCHvHnN2o/hELBu0z/2wbt3aYqK/FiZKvbmXL5rf9M/6rqoMqh9pLczAM
+XPa6TiKSN5jJ4ODI/ZLQvsz5FKPrWWT62gWM/F7jmWj4kpcGxMWftjNzN/Ci4NK6
+G+tcKBp8LAHsJQ6i43hWlmZnFUSMfkVH+025OsFjNhWelKAX9bAo7apb4ItqjTpL
+YxS0cMrVi/pwaRAMpeG8uq7YSDISvG3iuNz7OAOptuJ6GXEPgGHpzhyFeHUQgKYi
+7N9NfVTRTrFZY58hxZxh41t5LfLzxm6tUkvqDqfIdEpaFWCtaicTB/+gAbrhQ2Qg
+RQIDAQAB
+-----END PUBLIC KEY-----"#;
 
     /// Stateless slice of the router so /health can be tested without a live JWKS.
     fn health_only_router() -> Router {
         Router::new().route("/api/v1/health", get(health_handler))
+    }
+
+    async fn owner_test_router(owner_user_id: &str) -> (Router, tempfile::TempDir) {
+        let tmp = tempfile::tempdir().unwrap();
+        let jwks = Arc::new(JwksClient::for_test(
+            TEST_ISSUER,
+            TEST_AUD,
+            TEST_KID,
+            Arc::new(DecodingKey::from_rsa_pem(TEST_PUBLIC_KEY.as_bytes()).unwrap()),
+        ));
+        let owner = Arc::new(OwnerAuthorizer::new(owner_user_id).unwrap());
+        let workspaces = Arc::new(
+            WorkspaceManager::new(tmp.path().join("home"))
+                .await
+                .unwrap(),
+        );
+        let terminals = Arc::new(TerminalManager::new());
+        (
+            router(AppState {
+                jwks,
+                owner,
+                workspaces,
+                terminals,
+            }),
+            tmp,
+        )
+    }
+
+    fn signed_token(user_id: &str) -> String {
+        let now = Utc::now().timestamp();
+        let claims = json!({
+            "iss": TEST_ISSUER,
+            "aud": TEST_AUD,
+            "sub": user_id,
+            "iat": now,
+            "exp": now + 3600,
+        });
+        let mut header = Header::new(Algorithm::RS256);
+        header.kid = Some(TEST_KID.to_string());
+        encode(
+            &header,
+            &claims,
+            &EncodingKey::from_rsa_pem(TEST_PRIVATE_KEY.as_bytes()).unwrap(),
+        )
+        .unwrap()
+    }
+
+    fn list_workspaces_request(token: Option<String>) -> Request<axum::body::Body> {
+        let mut builder = Request::builder().uri("/api/v1/workspaces");
+        if let Some(token) = token {
+            builder = builder.header(IDENTITY_TOKEN_HEADER, token);
+        }
+        builder.body(axum::body::Body::empty()).unwrap()
     }
 
     #[tokio::test]
@@ -353,5 +466,38 @@ mod tests {
         let parsed: HealthResponse = serde_json::from_slice(&body).unwrap();
         assert!(parsed.ok);
         assert_eq!(parsed.version, DAEMON_VERSION);
+    }
+
+    #[tokio::test]
+    async fn workspace_routes_allow_configured_owner() {
+        let (app, _tmp) = owner_test_router("owner-123").await;
+        let resp = app
+            .oneshot(list_workspaces_request(Some(signed_token("owner-123"))))
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = to_bytes(resp.into_body(), 64 * 1024).await.unwrap();
+        let parsed: ListWorkspacesResponse = serde_json::from_slice(&body).unwrap();
+        assert!(parsed.workspaces.is_empty());
+    }
+
+    #[tokio::test]
+    async fn workspace_routes_reject_non_owner() {
+        let (app, _tmp) = owner_test_router("owner-123").await;
+        let resp = app
+            .oneshot(list_workspaces_request(Some(signed_token("other-user"))))
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn workspace_routes_reject_missing_token() {
+        let (app, _tmp) = owner_test_router("owner-123").await;
+        let resp = app.oneshot(list_workspaces_request(None)).await.unwrap();
+
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
     }
 }

--- a/crates/charon-daemon/src/nyxid_jwt.rs
+++ b/crates/charon-daemon/src/nyxid_jwt.rs
@@ -90,6 +90,42 @@ pub enum JwtError {
     JwksStatus(reqwest::StatusCode),
 }
 
+#[derive(Debug, Error)]
+pub enum OwnerAuthError {
+    #[error("owner user id must not be empty")]
+    EmptyOwnerUserId,
+    #[error("identity user_id '{actual}' is not configured owner")]
+    UserMismatch { actual: String },
+}
+
+#[derive(Debug)]
+pub struct OwnerAuthorizer {
+    owner_user_id: String,
+}
+
+impl OwnerAuthorizer {
+    pub fn new(owner_user_id: impl Into<String>) -> Result<Self, OwnerAuthError> {
+        let owner_user_id = owner_user_id.into().trim().to_string();
+        if owner_user_id.is_empty() {
+            return Err(OwnerAuthError::EmptyOwnerUserId);
+        }
+        Ok(Self { owner_user_id })
+    }
+
+    pub fn owner_user_id(&self) -> &str {
+        &self.owner_user_id
+    }
+
+    pub fn authorize(&self, identity: &NyxIdentity) -> Result<(), OwnerAuthError> {
+        if identity.user_id == self.owner_user_id {
+            return Ok(());
+        }
+        Err(OwnerAuthError::UserMismatch {
+            actual: identity.user_id.clone(),
+        })
+    }
+}
+
 pub struct JwksClient {
     issuer: String,
     expected_aud: String,
@@ -280,6 +316,37 @@ impl JwksClient {
     }
 }
 
+#[cfg(test)]
+impl JwksClient {
+    /// Convenience constructor used by lib.rs router tests — installs a single
+    /// (kid → key) entry and uses the production HTTP fetcher + system clock.
+    /// For verifier-internal tests with injected fetchers / manual clocks see
+    /// `new_for_test` in the tests module.
+    pub(crate) fn for_test(
+        issuer: impl Into<String>,
+        expected_aud: impl Into<String>,
+        kid: impl Into<String>,
+        key: Arc<DecodingKey>,
+    ) -> Self {
+        let mut keys = KeyMap::new();
+        keys.insert(kid.into(), key);
+        let clock: Arc<dyn Clock> = Arc::new(SystemClock);
+        Self {
+            issuer: issuer.into(),
+            expected_aud: expected_aud.into(),
+            http: reqwest::Client::new(),
+            jwks_fetcher: Arc::new(HttpJwksFetcher),
+            clock: clock.clone(),
+            inner: RwLock::new(Cache {
+                jwks_uri: "test://jwks".to_string(),
+                keys,
+                fetched_at: clock.now(),
+                last_kid_miss_refresh_at: None,
+            }),
+        }
+    }
+}
+
 async fn fetch_jwks(http: &reqwest::Client, jwks_uri: &str) -> Result<KeyMap, JwtError> {
     let resp = http
         .get(jwks_uri)
@@ -333,6 +400,8 @@ fn claims_to_identity(raw: RawClaims) -> NyxIdentity {
 
 pub struct IdentityToken(pub NyxIdentity);
 
+pub struct OwnerIdentity(pub NyxIdentity);
+
 impl<S> FromRequestParts<S> for IdentityToken
 where
     S: Send + Sync,
@@ -369,6 +438,31 @@ where
                 Err(reject(status, "invalid_token", e))
             }
         }
+    }
+}
+
+impl<S> FromRequestParts<S> for OwnerIdentity
+where
+    S: Send + Sync,
+    Arc<JwksClient>: FromRef<S>,
+    Arc<OwnerAuthorizer>: FromRef<S>,
+{
+    type Rejection = (StatusCode, Json<crate::ErrorBody>);
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        let IdentityToken(identity) = IdentityToken::from_request_parts(parts, state).await?;
+        let owner: Arc<OwnerAuthorizer> = FromRef::from_ref(state);
+        owner.authorize(&identity).map_err(|e| {
+            warn!(user_id = %identity.user_id, error = %e, "rejecting non-owner request");
+            (
+                StatusCode::FORBIDDEN,
+                Json(crate::ErrorBody {
+                    error: "not_owner",
+                    message: e.to_string(),
+                }),
+            )
+        })?;
+        Ok(OwnerIdentity(identity))
     }
 }
 

--- a/crates/charon-daemon/src/ws.rs
+++ b/crates/charon-daemon/src/ws.rs
@@ -21,7 +21,7 @@ use chrono::Utc;
 use tokio::sync::broadcast::error::RecvError;
 use tracing::{debug, info, warn};
 
-use crate::nyxid_jwt::IdentityToken;
+use crate::nyxid_jwt::OwnerIdentity;
 use crate::terminal::{TerminalEvent, TerminalManager};
 use crate::workspace::WorkspaceManager;
 use crate::{AppState, diff, files};
@@ -31,7 +31,7 @@ const HEARTBEAT: Duration = Duration::from_secs(60);
 pub async fn ws_upgrade_handler(
     ws: WebSocketUpgrade,
     State(state): State<AppState>,
-    IdentityToken(identity): IdentityToken,
+    OwnerIdentity(identity): OwnerIdentity,
 ) -> Response {
     info!(user_id = %identity.user_id, "WS upgrade");
     ws.on_upgrade(move |socket| run_session(socket, state, identity))

--- a/docs/05-poc-results-and-next-steps.md
+++ b/docs/05-poc-results-and-next-steps.md
@@ -165,9 +165,18 @@ All checks passed.
 | `CHARON_BIND` | `127.0.0.1:18789` | daemon 监听地址 |
 | `CHARON_EXPECTED_AUD` | `http://localhost:18789` | JWT `aud` 校验值（必须 == UserService endpoint URL） |
 | `CHARON_NYXID_ISSUER` | `https://nyx-api.chrono-ai.fun` | OIDC discovery / JWT `iss` 校验值 |
+| `CHARON_OWNER_USER_ID` | 无，必填 | daemon 单 owner 授权；workspace/file/diff/WS 只接受 JWT `sub == owner` |
 | `CHARON_ENDPOINT` | `http://127.0.0.1:18789` | doctor 探本地 daemon |
 | `CHARON_NYXID_BASE_URL` | `https://nyx-api.chrono-ai.fun` | doctor 走的 proxy 根 URL（M1 等于 issuer） |
 | `CHARON_DOCTOR_SLUG` | `charon-echo-poc` | doctor 经 proxy 打的 UserService slug |
+
+第一次升级后如果还不知道自己的 NyxID `user_id`，可以先用临时值启动 daemon，只打 `/whoami` 拿真实值，再改成真实 owner 重启：
+
+```bash
+CHARON_OWNER_USER_ID=bootstrap cargo run -p charon-daemon
+curl -H "Authorization: Bearer $(cat ~/.nyxid/access_token)" \
+  https://nyx-api.chrono-ai.fun/api/v1/proxy/s/charon-echo-poc/api/v1/whoami
+```
 
 ### #3 端到端验证
 

--- a/docs/06-m2-plan.md
+++ b/docs/06-m2-plan.md
@@ -35,7 +35,7 @@
 | env | 默认 | 谁用 |
 |---|---|---|
 | `CHARON_HOME` | `~/.charon` | workspaces.json + worktrees/ + (M2.6) config.toml 都在这下面 |
-| `CHARON_OWNER_USER_ID` | （从 M2.6 config.toml 读） | 单用户校验 — 只接受 JWT `sub == owner` 的请求 |
+| `CHARON_OWNER_USER_ID` | 必填（M2.6 后可从 config.toml 读） | 单用户校验 — 只接受 JWT `sub == owner` 的请求 |
 
 ---
 


### PR DESCRIPTION
## Summary

- Add required `CHARON_OWNER_USER_ID` daemon config and CLI startup wiring.
- Introduce a reusable `OwnerIdentity` extractor that verifies the NyxID JWT and rejects non-owner identities with `403` before REST handlers or WS upgrade sessions run.
- Switch authenticated daemon routes and the WS upgrade path to the owner guard, and add route-level tests for owner allow, non-owner reject, and missing-token reject.
- Document the M2 env requirement.

Fixes #1.

## Validation

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo build --workspace`