### PR TITLE
[codex] fix workspace persistence transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,6 +261,7 @@ dependencies = [
  "bytes",
  "charon-core",
  "chrono",
+ "fs2",
  "jsonwebtoken",
  "portable-pty",
  "reqwest",
@@ -456,6 +457,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ thiserror = "2"
 # misc
 futures = "0.3.31"
 directories = "6"
+fs2 = "0.4"
 tempfile = "3"
 base64 = "0.22"
 bytes = "1"

--- a/crates/charon-daemon/Cargo.toml
+++ b/crates/charon-daemon/Cargo.toml
@@ -41,6 +41,7 @@ tracing-subscriber.workspace = true
 
 anyhow.workspace = true
 thiserror.workspace = true
+fs2.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/charon-daemon/src/workspace.rs
+++ b/crates/charon-daemon/src/workspace.rs
@@ -8,36 +8,113 @@
 //! Archive is soft-delete only: `archived_at` is set, the worktree stays on
 //! disk. Hard delete + cascade kill of agents/terminals lands in M3.
 
-use std::path::{Path, PathBuf};
+use std::{
+    collections::HashSet,
+    fs::{File, OpenOptions},
+    path::{Path, PathBuf},
+};
 
 use anyhow::{Context, Result, bail};
 use charon_core::{CreateWorkspaceRequest, Workspace};
-use chrono::Utc;
+use chrono::{DateTime, Utc};
+use fs2::FileExt;
 use serde::{Deserialize, Serialize};
 use tokio::process::Command;
 use tokio::sync::RwLock;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 use uuid::Uuid;
 
+const STORE_VERSION: u32 = 1;
 const STORE_FILE: &str = "workspaces.json";
 const WORKTREES_DIR: &str = "worktrees";
+const LOCK_FILE: &str = ".lock";
 
-#[derive(Debug, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
 struct WorkspaceStore {
-    workspaces: Vec<Workspace>,
+    version: u32,
+    workspaces: Vec<WorkspaceRecord>,
+}
+
+impl Default for WorkspaceStore {
+    fn default() -> Self {
+        Self {
+            version: STORE_VERSION,
+            workspaces: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct WorkspaceRecord {
+    id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    title: Option<String>,
+    project_root: PathBuf,
+    base_branch: String,
+    branch: String,
+    worktree_path: PathBuf,
+    created_at: DateTime<Utc>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    archived_at: Option<DateTime<Utc>>,
+}
+
+impl From<Workspace> for WorkspaceRecord {
+    fn from(workspace: Workspace) -> Self {
+        Self {
+            id: workspace.id,
+            title: workspace.title,
+            project_root: workspace.project_root,
+            base_branch: workspace.base_branch,
+            branch: workspace.branch,
+            worktree_path: workspace.worktree_path,
+            created_at: workspace.created_at,
+            archived_at: workspace.archived_at,
+        }
+    }
+}
+
+impl From<&WorkspaceRecord> for Workspace {
+    fn from(record: &WorkspaceRecord) -> Self {
+        Self {
+            id: record.id.clone(),
+            title: record.title.clone(),
+            project_root: record.project_root.clone(),
+            base_branch: record.base_branch.clone(),
+            branch: record.branch.clone(),
+            worktree_path: record.worktree_path.clone(),
+            created_at: record.created_at,
+            archived_at: record.archived_at,
+        }
+    }
 }
 
 pub struct WorkspaceManager {
     home: PathBuf,
+    _lock_file: File,
+    _orphaned_worktrees: Vec<PathBuf>,
     store: RwLock<WorkspaceStore>,
 }
 
 impl WorkspaceManager {
     pub async fn new(home: PathBuf) -> Result<Self> {
+        tokio::fs::create_dir_all(&home)
+            .await
+            .with_context(|| format!("create_dir_all {}", home.display()))?;
+        let lock_file = acquire_home_lock(&home)?;
         tokio::fs::create_dir_all(home.join(WORKTREES_DIR))
             .await
             .with_context(|| format!("create_dir_all {}", home.display()))?;
         let store = load_store(&home.join(STORE_FILE)).await?;
+        let orphaned_worktrees = detect_orphaned_worktrees(&home.join(WORKTREES_DIR), &store)
+            .await
+            .with_context(|| format!("scan orphaned worktrees under {}", home.display()))?;
+        if !orphaned_worktrees.is_empty() {
+            warn!(
+                count = orphaned_worktrees.len(),
+                paths = ?orphaned_worktrees,
+                "orphaned workspace worktrees detected"
+            );
+        }
         info!(
             home = %home.display(),
             workspaces = store.workspaces.len(),
@@ -45,6 +122,8 @@ impl WorkspaceManager {
         );
         Ok(Self {
             home,
+            _lock_file: lock_file,
+            _orphaned_worktrees: orphaned_worktrees,
             store: RwLock::new(store),
         })
     }
@@ -74,7 +153,7 @@ impl WorkspaceManager {
         let workspace = Workspace {
             id,
             title: req.title,
-            project_root,
+            project_root: project_root.clone(),
             base_branch,
             branch: new_branch,
             worktree_path,
@@ -83,8 +162,37 @@ impl WorkspaceManager {
         };
 
         let mut store = self.store.write().await;
-        store.workspaces.push(workspace.clone());
-        save_store(&self.home.join(STORE_FILE), &store).await?;
+        let mut next_store = store.clone();
+        next_store
+            .workspaces
+            .push(WorkspaceRecord::from(workspace.clone()));
+        if let Err(save_err) = save_store(&self.home.join(STORE_FILE), &next_store).await {
+            match rollback_created_worktree(
+                &project_root,
+                &workspace.worktree_path,
+                &workspace.branch,
+            )
+            .await
+            {
+                Ok(()) => {
+                    return Err(save_err).with_context(|| {
+                        format!(
+                            "persist workspace {}; rolled back git worktree and branch",
+                            workspace.id
+                        )
+                    });
+                }
+                Err(rollback_err) => {
+                    return Err(save_err).with_context(|| {
+                        format!(
+                            "persist workspace {}; rollback failed: {rollback_err}",
+                            workspace.id
+                        )
+                    });
+                }
+            }
+        }
+        *store = next_store;
         info!(
             id = %workspace.id,
             branch = %workspace.branch,
@@ -100,27 +208,34 @@ impl WorkspaceManager {
             .workspaces
             .iter()
             .filter(|w| include_archived || w.archived_at.is_none())
-            .cloned()
+            .map(Workspace::from)
             .collect()
     }
 
     pub async fn get(&self, id: &str) -> Option<Workspace> {
         let store = self.store.read().await;
-        store.workspaces.iter().find(|w| w.id == id).cloned()
+        store
+            .workspaces
+            .iter()
+            .find(|w| w.id == id)
+            .map(Workspace::from)
     }
 
     pub async fn archive(&self, id: &str) -> Result<Workspace> {
         let mut store = self.store.write().await;
-        let workspace = store
+        let idx = store
             .workspaces
-            .iter_mut()
-            .find(|w| w.id == id)
+            .iter()
+            .position(|w| w.id == id)
             .with_context(|| format!("workspace {id} not found"))?;
-        if workspace.archived_at.is_none() {
-            workspace.archived_at = Some(Utc::now());
+        let mut next_store = store.clone();
+        let record = &mut next_store.workspaces[idx];
+        if record.archived_at.is_none() {
+            record.archived_at = Some(Utc::now());
         }
-        let cloned = workspace.clone();
-        save_store(&self.home.join(STORE_FILE), &store).await?;
+        let cloned = Workspace::from(&*record);
+        save_store(&self.home.join(STORE_FILE), &next_store).await?;
+        *store = next_store;
         info!(id = %cloned.id, "workspace archived");
         Ok(cloned)
     }
@@ -133,7 +248,9 @@ async fn load_store(path: &Path) -> Result<WorkspaceStore> {
     let bytes = tokio::fs::read(path)
         .await
         .with_context(|| format!("read {}", path.display()))?;
-    serde_json::from_slice(&bytes).with_context(|| format!("parse {}", path.display()))
+    let disk: WorkspaceStoreFile =
+        serde_json::from_slice(&bytes).with_context(|| format!("parse {}", path.display()))?;
+    disk.into_store()
 }
 
 async fn save_store(path: &Path, store: &WorkspaceStore) -> Result<()> {
@@ -146,6 +263,111 @@ async fn save_store(path: &Path, store: &WorkspaceStore) -> Result<()> {
         .await
         .with_context(|| format!("rename {} → {}", tmp.display(), path.display()))?;
     Ok(())
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum WorkspaceStoreFile {
+    Versioned(VersionedWorkspaceStore),
+    LegacyObject(LegacyWorkspaceStore),
+    LegacyArray(Vec<WorkspaceRecord>),
+}
+
+impl WorkspaceStoreFile {
+    fn into_store(self) -> Result<WorkspaceStore> {
+        match self {
+            Self::Versioned(store) => {
+                if store.version != STORE_VERSION {
+                    bail!(
+                        "unsupported workspace store version {}; expected {}",
+                        store.version,
+                        STORE_VERSION
+                    );
+                }
+                Ok(WorkspaceStore {
+                    version: store.version,
+                    workspaces: store.workspaces,
+                })
+            }
+            Self::LegacyObject(store) => Ok(WorkspaceStore {
+                version: STORE_VERSION,
+                workspaces: store.workspaces,
+            }),
+            Self::LegacyArray(workspaces) => Ok(WorkspaceStore {
+                version: STORE_VERSION,
+                workspaces,
+            }),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct VersionedWorkspaceStore {
+    version: u32,
+    workspaces: Vec<WorkspaceRecord>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LegacyWorkspaceStore {
+    workspaces: Vec<WorkspaceRecord>,
+}
+
+fn acquire_home_lock(home: &Path) -> Result<File> {
+    let lock_path = home.join(LOCK_FILE);
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(&lock_path)
+        .with_context(|| format!("open {}", lock_path.display()))?;
+    file.try_lock_exclusive()
+        .with_context(|| format!("lock {}", lock_path.display()))?;
+    Ok(file)
+}
+
+async fn detect_orphaned_worktrees(
+    worktrees_dir: &Path,
+    store: &WorkspaceStore,
+) -> Result<Vec<PathBuf>> {
+    if !worktrees_dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    let expected_ids: HashSet<String> = store.workspaces.iter().map(|w| w.id.clone()).collect();
+    let expected_paths: HashSet<PathBuf> = store
+        .workspaces
+        .iter()
+        .map(|w| w.worktree_path.clone())
+        .collect();
+    let mut orphans = Vec::new();
+    let mut entries = tokio::fs::read_dir(worktrees_dir)
+        .await
+        .with_context(|| format!("read_dir {}", worktrees_dir.display()))?;
+    while let Some(entry) = entries
+        .next_entry()
+        .await
+        .with_context(|| format!("read_dir entry {}", worktrees_dir.display()))?
+    {
+        let ty = entry
+            .file_type()
+            .await
+            .with_context(|| format!("file_type {}", entry.path().display()))?;
+        if !ty.is_dir() {
+            continue;
+        }
+        let path = entry.path();
+        let file_name = entry.file_name();
+        let id_is_recorded = file_name
+            .to_str()
+            .map(|name| expected_ids.contains(name))
+            .unwrap_or(false);
+        if !id_is_recorded && !expected_paths.contains(&path) {
+            orphans.push(path);
+        }
+    }
+    orphans.sort();
+    Ok(orphans)
 }
 
 async fn ensure_git_repo(path: &Path) -> Result<()> {
@@ -218,6 +440,82 @@ async fn git_worktree_add(
     Ok(())
 }
 
+async fn rollback_created_worktree(
+    project_root: &Path,
+    worktree_path: &Path,
+    branch: &str,
+) -> Result<()> {
+    let mut failures = Vec::new();
+
+    if worktree_path.exists()
+        && let Err(err) = git_worktree_remove(project_root, worktree_path).await
+    {
+        failures.push(format!("remove worktree: {err:#}"));
+    }
+
+    if let Err(err) = git_branch_delete(project_root, branch).await {
+        failures.push(format!("delete branch {branch}: {err:#}"));
+    }
+
+    if failures.is_empty() {
+        info!(
+            branch = %branch,
+            path = %worktree_path.display(),
+            "rolled back workspace git artifacts"
+        );
+        Ok(())
+    } else {
+        bail!("{}", failures.join("; "))
+    }
+}
+
+async fn git_worktree_remove(project_root: &Path, worktree_path: &Path) -> Result<()> {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(project_root)
+        .args(["worktree", "remove", "--force"])
+        .arg(worktree_path)
+        .output()
+        .await
+        .context("exec `git worktree remove --force`")?;
+    if !out.status.success() {
+        bail!(
+            "git worktree remove failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        );
+    }
+    Ok(())
+}
+
+async fn git_branch_delete(project_root: &Path, branch: &str) -> Result<()> {
+    let refname = format!("refs/heads/{branch}");
+    let exists = Command::new("git")
+        .arg("-C")
+        .arg(project_root)
+        .args(["show-ref", "--verify", "--quiet", &refname])
+        .status()
+        .await
+        .context("exec `git show-ref --verify --quiet`")?;
+    if !exists.success() {
+        return Ok(());
+    }
+
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(project_root)
+        .args(["branch", "-D", branch])
+        .output()
+        .await
+        .context("exec `git branch -D`")?;
+    if !out.status.success() {
+        bail!(
+            "git branch -D failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        );
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -245,6 +543,22 @@ mod tests {
             "git {args:?} failed: {}",
             String::from_utf8_lossy(&out.stderr)
         );
+    }
+
+    async fn git_stdout(cwd: &Path, args: &[&str]) -> String {
+        let out = Command::new("git")
+            .arg("-C")
+            .arg(cwd)
+            .args(args)
+            .output()
+            .await
+            .unwrap();
+        assert!(
+            out.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        String::from_utf8(out.stdout).unwrap()
     }
 
     #[tokio::test]
@@ -281,6 +595,10 @@ mod tests {
         assert!(archived.archived_at.is_some());
         assert!(mgr.list(false).await.is_empty());
         assert_eq!(mgr.list(true).await.len(), 1);
+        let stored: serde_json::Value =
+            serde_json::from_slice(&tokio::fs::read(charon_home.join(STORE_FILE)).await.unwrap())
+                .unwrap();
+        assert_eq!(stored["version"], STORE_VERSION);
 
         // Persistence: a fresh manager loading the same home should see the workspace.
         drop(mgr);
@@ -289,6 +607,93 @@ mod tests {
         assert_eq!(after_reload.len(), 1);
         assert_eq!(after_reload[0].id, ws.id);
         assert!(after_reload[0].archived_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn migrates_legacy_workspace_store_shape() {
+        let tmp = TempDir::new().unwrap();
+        let project = tmp.path().join("project");
+        let charon_home = tmp.path().join("charon-home");
+        let worktrees = charon_home.join(WORKTREES_DIR);
+        let worktree_path = worktrees.join("legacy-id");
+        init_repo(&project).await;
+        tokio::fs::create_dir_all(&worktree_path).await.unwrap();
+
+        let legacy = serde_json::json!({
+            "workspaces": [{
+                "id": "legacy-id",
+                "title": "legacy",
+                "project_root": project,
+                "base_branch": "main",
+                "branch": "legacy/branch",
+                "worktree_path": worktree_path,
+                "created_at": Utc::now(),
+                "archived_at": null
+            }]
+        });
+        tokio::fs::create_dir_all(&charon_home).await.unwrap();
+        tokio::fs::write(
+            charon_home.join(STORE_FILE),
+            serde_json::to_vec_pretty(&legacy).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        let mgr = WorkspaceManager::new(charon_home).await.unwrap();
+        let listed = mgr.list(true).await;
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].id, "legacy-id");
+        assert_eq!(listed[0].branch, "legacy/branch");
+    }
+
+    #[tokio::test]
+    async fn reports_orphaned_worktree_dirs_on_startup() {
+        let tmp = TempDir::new().unwrap();
+        let charon_home = tmp.path().join("charon-home");
+        let orphan = charon_home.join(WORKTREES_DIR).join("orphan-id");
+        tokio::fs::create_dir_all(&orphan).await.unwrap();
+
+        let mgr = WorkspaceManager::new(charon_home).await.unwrap();
+        assert_eq!(mgr._orphaned_worktrees, vec![orphan]);
+    }
+
+    #[tokio::test]
+    async fn failed_save_rolls_back_worktree_branch_and_memory() {
+        let tmp = TempDir::new().unwrap();
+        let project = tmp.path().join("project");
+        let charon_home = tmp.path().join("charon-home");
+        init_repo(&project).await;
+
+        let mgr = WorkspaceManager::new(charon_home.clone()).await.unwrap();
+        tokio::fs::create_dir(charon_home.join("workspaces.json.tmp"))
+            .await
+            .unwrap();
+        let err = mgr
+            .create(CreateWorkspaceRequest {
+                project_root: project.clone(),
+                title: Some("rollback".into()),
+                base_branch: Some("main".into()),
+                new_branch: Some("feat/rollback".into()),
+            })
+            .await
+            .unwrap_err();
+
+        assert!(
+            err.to_string().contains("rolled back"),
+            "expected rollback context, got: {err:#}"
+        );
+        assert!(mgr.list(true).await.is_empty());
+
+        let mut entries = tokio::fs::read_dir(charon_home.join(WORKTREES_DIR))
+            .await
+            .unwrap();
+        assert!(entries.next_entry().await.unwrap().is_none());
+
+        let branches = git_stdout(&project, &["branch", "--list", "feat/rollback"]).await;
+        assert!(
+            branches.trim().is_empty(),
+            "branch still exists: {branches}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Fixes #3.

- Adds an explicit `version` field and internal `WorkspaceRecord` store type for workspace persistence.
- Migrates the existing unversioned M2.1 store shape on load, while keeping the public `Workspace` wire type separate from storage.
- Holds a process-level `CHARON_HOME` lock while the daemon is alive.
- Rolls back the git worktree and newly-created branch if persisting a newly-created workspace fails.
- Detects and reports orphaned worktree directories under `worktrees/` during startup.

## Tests

- `workspace::tests::failed_save_rolls_back_worktree_branch_and_memory` covers save failure rollback of the git worktree, branch, and in-memory store.
- `workspace::tests::migrates_legacy_workspace_store_shape` covers loading the old unversioned M2.1 JSON store shape into the versioned schema.
- `workspace::tests::reports_orphaned_worktree_dirs_on_startup` covers startup orphan detection under `worktrees/`.

## Validation

- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build --workspace`
- `cargo test --workspace`
- `git diff --check`