### PR TITLE
[codex] Fix terminal resource cleanup

### DIFF
--- a/crates/charon-core/src/lib.rs
+++ b/crates/charon-core/src/lib.rs
@@ -10,9 +10,10 @@ pub use wire::{
     DiffStatus, FileContent, FileDiff, FileEntry, FileKind, FilePathPayload, FileTreePayload,
     FileTreeResponse, FileWritePayload, HealthResponse, HelloPayload, ListWorkspacesResponse,
     NyxIdentity, ServerFrame, ServerInfo, Terminal, TerminalIdPayload, TerminalKeysAck,
-    TerminalKillAck, TerminalListPayload, TerminalListResponse, TerminalResizeAck,
-    TerminalResizePayload, TerminalScrollbackResponse, TerminalSendKeysPayload, TerminalStatus,
-    WhoAmIResponse, Workspace, WorkspaceIdPayload, WorkspaceListPayload, WriteFileRequest, WsError,
+    TerminalKillAck, TerminalListPayload, TerminalListResponse, TerminalRemoveAck,
+    TerminalResizeAck, TerminalResizePayload, TerminalScrollbackResponse, TerminalSendKeysPayload,
+    TerminalStatus, WhoAmIResponse, Workspace, WorkspaceIdPayload, WorkspaceListPayload,
+    WriteFileRequest, WsError,
 };
 
 /// Default loopback bind for the daemon. Mirrored by the existing

--- a/crates/charon-core/src/wire.rs
+++ b/crates/charon-core/src/wire.rs
@@ -145,6 +145,11 @@ pub enum ClientFrame {
         id: String,
         payload: TerminalIdPayload,
     },
+    #[serde(rename = "Terminal.Remove")]
+    TerminalRemove {
+        id: String,
+        payload: TerminalIdPayload,
+    },
     #[serde(rename = "Terminal.List")]
     TerminalList {
         id: String,
@@ -196,6 +201,11 @@ pub enum ServerFrame {
     },
     #[serde(rename = "Terminal.Killed")]
     TerminalKilled { id: String, result: TerminalKillAck },
+    #[serde(rename = "Terminal.Removed")]
+    TerminalRemoved {
+        id: String,
+        result: TerminalRemoveAck,
+    },
     #[serde(rename = "Terminal.Listed")]
     TerminalListed {
         id: String,
@@ -403,6 +413,11 @@ pub struct TerminalResizeAck {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TerminalKillAck {
+    pub terminal_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TerminalRemoveAck {
     pub terminal_id: String,
 }
 

--- a/crates/charon-daemon/src/terminal.rs
+++ b/crates/charon-daemon/src/terminal.rs
@@ -27,7 +27,7 @@ use charon_core::{
     TerminalStatus, Workspace,
 };
 use chrono::Utc;
-use portable_pty::{CommandBuilder, MasterPty, PtySize, native_pty_system};
+use portable_pty::{ChildKiller, CommandBuilder, MasterPty, PtySize, native_pty_system};
 use tokio::sync::{RwLock, broadcast};
 use tracing::{debug, info, warn};
 use uuid::Uuid;
@@ -56,9 +56,10 @@ pub struct TerminalManager {
 
 struct TerminalHandle {
     info: std::sync::Mutex<Terminal>,
-    master: std::sync::Mutex<Box<dyn MasterPty + Send>>,
-    writer: std::sync::Mutex<Box<dyn Write + Send>>,
-    child: std::sync::Mutex<Box<dyn portable_pty::Child + Send + Sync>>,
+    master: std::sync::Mutex<Option<Box<dyn MasterPty + Send>>>,
+    writer: std::sync::Mutex<Option<Box<dyn Write + Send>>>,
+    child: std::sync::Mutex<Option<Box<dyn portable_pty::Child + Send + Sync>>>,
+    killer: std::sync::Mutex<Option<Box<dyn ChildKiller + Send + Sync>>>,
     scrollback: std::sync::Mutex<VecDeque<u8>>,
     next_seq: AtomicU64,
 }
@@ -112,6 +113,7 @@ impl TerminalManager {
             .slave
             .spawn_command(cmd)
             .context("spawn command in PTY slave")?;
+        let killer = child.clone_killer();
         // Drop our slave handle so master EOFs cleanly when the child exits.
         drop(pair.slave);
 
@@ -132,9 +134,10 @@ impl TerminalManager {
 
         let handle = Arc::new(TerminalHandle {
             info: std::sync::Mutex::new(info.clone()),
-            master: std::sync::Mutex::new(pair.master),
-            writer: std::sync::Mutex::new(writer),
-            child: std::sync::Mutex::new(child),
+            master: std::sync::Mutex::new(Some(pair.master)),
+            writer: std::sync::Mutex::new(Some(writer)),
+            child: std::sync::Mutex::new(Some(child)),
+            killer: std::sync::Mutex::new(Some(killer)),
             scrollback: std::sync::Mutex::new(VecDeque::new()),
             next_seq: AtomicU64::new(0),
         });
@@ -189,9 +192,13 @@ impl TerminalManager {
 
     pub async fn send_keys(&self, terminal_id: &str, data: Vec<u8>) -> Result<usize> {
         let handle = self.get_handle(terminal_id).await?;
+        let terminal_id = terminal_id.to_string();
         let n = data.len();
         tokio::task::spawn_blocking(move || -> Result<()> {
             let mut writer = handle.writer.lock().unwrap();
+            let writer = writer
+                .as_mut()
+                .ok_or_else(|| anyhow!("terminal {terminal_id} has exited"))?;
             writer.write_all(&data).context("PTY write")?;
             writer.flush().ok();
             Ok(())
@@ -203,8 +210,12 @@ impl TerminalManager {
 
     pub async fn resize(&self, terminal_id: &str, cols: u16, rows: u16) -> Result<()> {
         let handle = self.get_handle(terminal_id).await?;
+        let terminal_id = terminal_id.to_string();
         tokio::task::spawn_blocking(move || -> Result<()> {
             let master = handle.master.lock().unwrap();
+            let master = master
+                .as_ref()
+                .ok_or_else(|| anyhow!("terminal {terminal_id} has exited"))?;
             master
                 .resize(PtySize {
                     rows,
@@ -225,13 +236,32 @@ impl TerminalManager {
 
     pub async fn kill(&self, terminal_id: &str) -> Result<()> {
         let handle = self.get_handle(terminal_id).await?;
-        tokio::task::spawn_blocking(move || {
-            let mut child = handle.child.lock().unwrap();
-            let _ = child.kill();
+        let terminal_id = terminal_id.to_string();
+        tokio::task::spawn_blocking(move || -> Result<()> {
+            let mut killer = handle.killer.lock().unwrap();
+            let killer = killer
+                .as_mut()
+                .ok_or_else(|| anyhow!("terminal {terminal_id} has exited"))?;
+            killer.kill().context("PTY child kill")?;
+            Ok(())
         })
         .await
-        .context("spawn_blocking kill")?;
+        .context("spawn_blocking kill")??;
         Ok(())
+    }
+
+    pub async fn remove(&self, terminal_id: &str) -> Result<Terminal> {
+        let mut map = self.inner.write().await;
+        let handle = map
+            .get(terminal_id)
+            .cloned()
+            .ok_or_else(|| anyhow!("terminal {terminal_id} not found"))?;
+        let info = handle.info.lock().unwrap().clone();
+        if info.status == TerminalStatus::Running {
+            return Err(anyhow!("terminal {terminal_id} is still running"));
+        }
+        map.remove(terminal_id);
+        Ok(info)
     }
 
     pub async fn scrollback(&self, terminal_id: &str) -> Result<TerminalScrollbackResponse> {
@@ -301,14 +331,25 @@ fn waiter_loop(
 ) {
     let exit_code: Option<i32> = {
         let mut child = handle.child.lock().unwrap();
-        match child.wait() {
-            Ok(status) => Some(status.exit_code() as i32),
-            Err(e) => {
-                warn!(?e, terminal_id, "child wait failed");
+        let exit_code = match child.as_mut() {
+            Some(child) => match child.wait() {
+                Ok(status) => Some(status.exit_code() as i32),
+                Err(e) => {
+                    warn!(?e, terminal_id, "child wait failed");
+                    None
+                }
+            },
+            None => {
+                warn!(terminal_id, "child handle already released before wait");
                 None
             }
-        }
+        };
+        *child = None;
+        exit_code
     };
+    *handle.writer.lock().unwrap() = None;
+    *handle.master.lock().unwrap() = None;
+    *handle.killer.lock().unwrap() = None;
     {
         let mut info = handle.info.lock().unwrap();
         info.status = TerminalStatus::Exited;
@@ -320,4 +361,139 @@ fn waiter_loop(
         exit_code,
     });
     info!(terminal_id, ?exit_code, "terminal exited");
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+    use std::time::Duration;
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn test_workspace(tmp: &TempDir) -> Workspace {
+        Workspace {
+            id: "ws-test".to_string(),
+            title: None,
+            project_root: tmp.path().to_path_buf(),
+            base_branch: "main".to_string(),
+            branch: "test".to_string(),
+            worktree_path: tmp.path().to_path_buf(),
+            created_at: Utc::now(),
+            archived_at: None,
+        }
+    }
+
+    fn command(candidates: &[&str], fallback: &str) -> String {
+        candidates
+            .iter()
+            .find(|candidate| Path::new(candidate).exists())
+            .copied()
+            .unwrap_or(fallback)
+            .to_string()
+    }
+
+    async fn wait_for_exit(
+        events: &mut broadcast::Receiver<TerminalEvent>,
+        terminal_id: &str,
+    ) -> Option<i32> {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                panic!("timed out waiting for terminal {terminal_id} exit");
+            }
+            match tokio::time::timeout(remaining, events.recv()).await {
+                Ok(Ok(TerminalEvent::Exited {
+                    terminal_id: id,
+                    exit_code,
+                })) if id == terminal_id => return exit_code,
+                Ok(Ok(_)) => {}
+                Ok(Err(e)) => panic!("terminal event channel failed: {e}"),
+                Err(_) => panic!("timed out waiting for terminal {terminal_id} exit"),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn exited_terminals_release_pty_resources_and_can_be_removed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let workspace = test_workspace(&tmp);
+        let manager = TerminalManager::new();
+        let mut events = manager.subscribe();
+        let true_cmd = command(&["/usr/bin/true", "/bin/true"], "true");
+        let mut terminal_ids = Vec::new();
+
+        for _ in 0..10 {
+            let terminal = manager
+                .create(
+                    &workspace,
+                    CreateTerminalPayload {
+                        workspace_id: workspace.id.clone(),
+                        command: Some(true_cmd.clone()),
+                        cols: 80,
+                        rows: 24,
+                    },
+                )
+                .await
+                .unwrap();
+            terminal_ids.push(terminal.id);
+        }
+
+        for terminal_id in &terminal_ids {
+            wait_for_exit(&mut events, terminal_id).await;
+        }
+
+        let listed = manager.list(Some(&workspace.id)).await;
+        assert_eq!(listed.len(), terminal_ids.len());
+        assert!(
+            listed
+                .iter()
+                .all(|terminal| terminal.status == TerminalStatus::Exited)
+        );
+
+        for terminal_id in &terminal_ids {
+            let handle = manager.get_handle(terminal_id).await.unwrap();
+            assert!(handle.master.lock().unwrap().is_none());
+            assert!(handle.writer.lock().unwrap().is_none());
+            assert!(handle.child.lock().unwrap().is_none());
+            assert!(handle.killer.lock().unwrap().is_none());
+
+            let removed = manager.remove(terminal_id).await.unwrap();
+            assert_eq!(removed.status, TerminalStatus::Exited);
+        }
+
+        assert!(manager.list(Some(&workspace.id)).await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn remove_refuses_running_terminals() {
+        let tmp = tempfile::tempdir().unwrap();
+        let workspace = test_workspace(&tmp);
+        let manager = TerminalManager::new();
+        let mut events = manager.subscribe();
+        let cat_cmd = command(&["/bin/cat", "/usr/bin/cat"], "cat");
+
+        let terminal = manager
+            .create(
+                &workspace,
+                CreateTerminalPayload {
+                    workspace_id: workspace.id.clone(),
+                    command: Some(cat_cmd),
+                    cols: 80,
+                    rows: 24,
+                },
+            )
+            .await
+            .unwrap();
+
+        let err = manager.remove(&terminal.id).await.unwrap_err();
+        assert!(err.to_string().contains("still running"));
+
+        manager.kill(&terminal.id).await.unwrap();
+        wait_for_exit(&mut events, &terminal.id).await;
+        manager.remove(&terminal.id).await.unwrap();
+        assert!(manager.list(Some(&workspace.id)).await.is_empty());
+    }
 }

--- a/crates/charon-daemon/src/ws.rs
+++ b/crates/charon-daemon/src/ws.rs
@@ -15,7 +15,7 @@ use axum::response::Response;
 use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
 use charon_core::{
     ClientFrame, DAEMON_VERSION, HelloPayload, ListWorkspacesResponse, NyxIdentity, ServerFrame,
-    ServerInfo, TerminalKeysAck, TerminalKillAck, TerminalResizeAck, WsError,
+    ServerInfo, TerminalKeysAck, TerminalKillAck, TerminalRemoveAck, TerminalResizeAck, WsError,
 };
 use chrono::Utc;
 use tokio::sync::broadcast::error::RecvError;
@@ -347,6 +347,23 @@ async fn dispatch(
                     .await;
                 }
                 Err(e) => send_error(socket, Some(id), "kill_failed", e.to_string()).await,
+            }
+        }
+        ClientFrame::TerminalRemove { id, payload } => {
+            match terminals.remove(&payload.terminal_id).await {
+                Ok(_) => {
+                    send_or_warn(
+                        socket,
+                        &ServerFrame::TerminalRemoved {
+                            id,
+                            result: TerminalRemoveAck {
+                                terminal_id: payload.terminal_id,
+                            },
+                        },
+                    )
+                    .await;
+                }
+                Err(e) => send_error(socket, Some(id), "remove_failed", e.to_string()).await,
             }
         }
         ClientFrame::TerminalList { id, payload } => {

--- a/docs/06-m2-plan.md
+++ b/docs/06-m2-plan.md
@@ -13,7 +13,7 @@
 | **M2.1 Workspace 模型** | git worktree manager（shell-out 到 `git`）、`~/.charon/workspaces.json` 持久化、`POST/GET /api/v1/workspaces`、`POST /api/v1/workspaces/:id/archive`，全部走 `IdentityToken` | M1 | ✅ 2026-04-25 |
 | **M2.2 WS 协议** | `GET /api/v1/ws` 升级（JWT at upgrade only）；JSON envelope；帧命名空间起步 `Workspace.*`；60s 服务端 Ping；Hello 帧带 identity；Error 帧带原 request id；二进制 attachment 留给 M2.3/M2.4 真用得着再做 | M2.1 | ✅ 2026-04-25 |
 | **M2.3 File / Diff API** | 路径 sandbox（lexical `safe_join`，拒 `../` + 绝对路径）；`File.{List,Read,Write}` REST + WS（UTF-8 only，binary 留 M2.4）；`Diff.Get` shell-out `git diff` + `ls-files --others`，per-file unified diff | M2.2 | ✅ 2026-04-26 |
-| **M2.4 Terminal** | `portable-pty` 起 shell；scrollback 1 MiB ring buffer；resize / kill / list / scrollback；server→client `Terminal.Output` 广播（base64-in-JSON）；`charon ws probe-terminal` 端到端 smoke | M2.2 | ✅ 2026-04-26 |
+| **M2.4 Terminal** | `portable-pty` 起 shell；scrollback 1 MiB ring buffer；resize / kill / list / scrollback / remove；server→client `Terminal.Output` 广播（base64-in-JSON）；`charon ws probe-terminal` 端到端 smoke | M2.2 | ✅ 2026-04-26 |
 | **M2.5 Tauri desktop shell** | `crates/charon-desktop`：Tauri v2 + React 19 + TanStack + Tailwind 4；NyxID OAuth in webview → UserService 发现 → WS 连接；workspace 树 / diff 视图 / xterm.js terminal | M2.2-M2.4 | ⏳ |
 | **M2.6 `charon link` + 配置收尾** | 自动化 `nyxid node register` + `nyxid service add`，把 slug/credential 写到 `~/.charon/config.toml`；`charon doctor` 改读 config 而不是 `DEFAULT_USER_SERVICE_SLUG` | 任意时机 | ⏳ |
 
@@ -156,10 +156,10 @@ JWT 验签发生在 `IdentityToken` extractor，axum 的 `WebSocketUpgrade` 也�
 
 | 步骤 | 状态 | 备注 |
 |---|---|---|
-| Terminal wire 类型 | ✅ | `Terminal` / `TerminalStatus` / `TerminalListResponse` / `TerminalScrollbackResponse` / `TerminalKeysAck` / `TerminalResizeAck` / `TerminalKillAck` + 5 个 WS payload；`ClientFrame` +6（Create/SendKeys/Resize/Kill/List/Scrollback）、`ServerFrame` +8（6 个 ack + 2 个 server-pushed Output/Exited） |
-| `charon-daemon::terminal` | ✅ | `TerminalManager` 用 `tokio::sync::broadcast` 全局广播 `TerminalEvent`；每 PTY 一个 blocking 线程 drain reader → scrollback ring (1 MiB) + broadcast；写 / resize / kill 走 `tokio::task::spawn_blocking`；child waiter 单线程 mark Exited 并广播 |
+| Terminal wire 类型 | ✅ | `Terminal` / `TerminalStatus` / `TerminalListResponse` / `TerminalScrollbackResponse` / `TerminalKeysAck` / `TerminalResizeAck` / `TerminalKillAck` / `TerminalRemoveAck` + 5 个 WS payload；`ClientFrame` +7（Create/SendKeys/Resize/Kill/Remove/List/Scrollback）、`ServerFrame` +9（7 个 ack + 2 个 server-pushed Output/Exited） |
+| `charon-daemon::terminal` | ✅ | `TerminalManager` 用 `tokio::sync::broadcast` 全局广播 `TerminalEvent`；每 PTY 一个 blocking 线程 drain reader → scrollback ring (1 MiB) + broadcast；写 / resize / kill 走 `tokio::task::spawn_blocking`；child waiter 单线程 mark Exited、释放 PTY master/writer/child/killer 并广播 |
 | AppState + WS 接线 | ✅ | `AppState.terminals: Arc<TerminalManager>` 加进 `FromRef`；`run_session` 多一个 `terminal_events.recv()` 分支，Lagged 时 warn 并提示重拉 scrollback |
-| WS dispatch 6 个 client frame | ✅ | `Terminal.Create` 拉 workspace + 起 PTY；`SendKeys` base64-decode 后写；`Resize/Kill/List/Scrollback` 直调 manager |
+| WS dispatch 7 个 client frame | ✅ | `Terminal.Create` 拉 workspace + 起 PTY；`SendKeys` base64-decode 后写；`Resize/Kill/Remove/List/Scrollback` 直调 manager |
 | `charon ws probe-terminal` CLI | ✅ | 自动 git-init `/tmp/charon-probe`、Hello → Workspace.Create → Terminal.Create → SendKeys "echo M24_SMOKE_OK; exit\n" → 等 Output 含 magic + Exited → 清理 archive |
 | 端到端实测 | ✅ | 见下文 |
 
@@ -196,7 +196,7 @@ DEBUG charon_daemon::ws: WS close from client
 
 - **没用 36B UUID 前缀的 binary attachment**：terminal output 直接 base64 in JSON。理由：典型 PTY chunk <1KB，base64 33% 开销 < 双帧（envelope + binary）开销；自包含帧好调试。等 M3 真有大 blob（文件 upload）再加 binary attachment 协议。
 - **Terminal subscriptions 不做**：所有 WS session 收所有 terminal 事件，client 自己按 terminal_id filter。简单，单用户场景够。多用户/多 client 真排队再考虑 explicit Subscribe / Unsubscribe。
-- **没 GC**：`Exited` 后 handle 留在 manager，方便事后查 scrollback。daemon 重启清空。等真撑爆内存再加 retention。
+- **Terminal GC 采用显式 remove**：`Exited` 后立即释放 PTY master/writer/child/killer；handle 暂留在 manager，方便事后查 list/scrollback。客户端调用 `Terminal.Remove` 后从 manager 删除；运行中的 terminal 拒绝 remove。
 - **continue 语句而不是 if-let-else**：每个 dispatch arm 自己手写 match-fetch-workspace-or-error，没抽 helper。9 个 arm 共有这个 pattern；后续重构时再合并。
 
 ### M2.3 偏差


### PR DESCRIPTION
## Summary

Fixes #12.

- Release terminal PTY master, writer, child, and cloned killer resources as soon as the waiter observes process exit, before broadcasting `Terminal.Exited`.
- Add explicit `Terminal.Remove` / `Terminal.Removed` WS support so exited terminal handles can be dropped from `TerminalManager::inner` while running terminals are rejected.
- Use `portable_pty::ChildKiller::clone_killer()` so `Terminal.Kill` can signal a process while the waiter thread is blocked in `wait()`.
- Update the M2 terminal notes to document the explicit remove model.

## Root Cause

`TerminalManager` kept each exited terminal handle in `inner`, and the handle owned the PTY master, writer, child, and scrollback until daemon shutdown. This retained file descriptors and up to 1 MiB of scrollback per exited terminal.

## Validation

- `cargo fmt`
- `cargo test -p charon-daemon terminal`
- `cargo test`
- `git diff --check`
