### PR TITLE
refactor(cli): probe-terminal cleanup and per-invocation tempdir

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -249,8 +249,6 @@ version = "0.0.1"
 dependencies = [
  "chrono",
  "serde",
- "serde_json",
- "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/crates/charon-cli/Cargo.toml
+++ b/crates/charon-cli/Cargo.toml
@@ -23,6 +23,7 @@ serde_json.workspace = true
 tokio-tungstenite.workspace = true
 futures.workspace = true
 base64.workspace = true
+tempfile.workspace = true
 zeroize.workspace = true
 
 tracing.workspace = true
@@ -30,5 +31,3 @@ tracing-subscriber.workspace = true
 
 anyhow.workspace = true
 
-[dev-dependencies]
-tempfile.workspace = true

--- a/crates/charon-cli/src/main.rs
+++ b/crates/charon-cli/src/main.rs
@@ -69,8 +69,9 @@ enum WsCmd {
         #[arg(long, env = "CHARON_DOCTOR_SLUG", default_value = DEFAULT_USER_SERVICE_SLUG)]
         slug: String,
         /// Project root for the throwaway workspace (auto git-init'd if needed).
-        #[arg(long, default_value = "/tmp/charon-probe")]
-        project_root: PathBuf,
+        /// Defaults to a fresh per-invocation tempdir, removed on exit.
+        #[arg(long)]
+        project_root: Option<PathBuf>,
     },
 }
 
@@ -143,7 +144,7 @@ async fn main() -> Result<()> {
                     slug,
                     project_root,
                 },
-        } => probe_terminal(&base_url, &slug, &project_root).await,
+        } => probe_terminal(&base_url, &slug, project_root).await,
     }
 }
 
@@ -316,9 +317,7 @@ async fn ws_handshake_probe(ws_url: &str) -> Result<NyxIdentity> {
             include_archived: true,
         },
     };
-    let req_text = serde_json::to_string(&req_frame).context("serialize Workspace.List")?;
-    socket
-        .send(TungsteniteMessage::Text(req_text.into()))
+    send_client_frame(&mut socket, &req_frame)
         .await
         .context("send Workspace.List")?;
     match recv_server_frame(&mut socket).await? {
@@ -376,23 +375,25 @@ where
 }
 
 async fn ensure_git_repo(path: &Path) -> Result<()> {
-    if !path.exists() {
-        std::fs::create_dir_all(path).with_context(|| format!("mkdir {}", path.display()))?;
-    }
-    let probe = std::process::Command::new("git")
+    tokio::fs::create_dir_all(path)
+        .await
+        .with_context(|| format!("mkdir {}", path.display()))?;
+    let probe = tokio::process::Command::new("git")
         .arg("-C")
         .arg(path)
         .args(["rev-parse", "--is-inside-work-tree"])
         .output()
+        .await
         .context("exec `git rev-parse`")?;
     if probe.status.success() {
         return Ok(());
     }
-    let init = std::process::Command::new("git")
+    let init = tokio::process::Command::new("git")
         .arg("-C")
         .arg(path)
         .args(["init", "-q", "-b", "main"])
         .output()
+        .await
         .context("exec `git init`")?;
     if !init.status.success() {
         bail!(
@@ -400,7 +401,7 @@ async fn ensure_git_repo(path: &Path) -> Result<()> {
             String::from_utf8_lossy(&init.stderr).trim()
         );
     }
-    let commit = std::process::Command::new("git")
+    let commit = tokio::process::Command::new("git")
         .arg("-C")
         .arg(path)
         .args([
@@ -415,6 +416,7 @@ async fn ensure_git_repo(path: &Path) -> Result<()> {
             "init",
         ])
         .output()
+        .await
         .context("exec `git commit`")?;
     if !commit.status.success() {
         bail!(
@@ -425,8 +427,17 @@ async fn ensure_git_repo(path: &Path) -> Result<()> {
     Ok(())
 }
 
-async fn probe_terminal(base_url: &str, slug: &str, project_root: &Path) -> Result<()> {
+async fn probe_terminal(base_url: &str, slug: &str, project_root: Option<PathBuf>) -> Result<()> {
     println!("== charon ws probe-terminal ==\n");
+
+    let (project_root, _temp_guard) = match project_root {
+        Some(p) => (p, None),
+        None => {
+            let td = tempfile::tempdir().context("create probe tempdir")?;
+            (td.path().to_path_buf(), Some(td))
+        }
+    };
+    let project_root = project_root.as_path();
 
     ensure_git_repo(project_root)
         .await

--- a/crates/charon-core/Cargo.toml
+++ b/crates/charon-core/Cargo.toml
@@ -9,6 +9,4 @@ description = "Charon shared types: wire protocol, identity, workspace/agent/ter
 
 [dependencies]
 serde.workspace = true
-serde_json.workspace = true
-thiserror.workspace = true
 chrono.workspace = true


### PR DESCRIPTION
Closes #19 and #15.

## Summary

- **charon-core deps** — drop unused `thiserror` and `serde_json` (#19.1).
- **`ws_handshake_probe`** — replace the inlined `serde_json::to_string` + `socket.send(Text)` with the existing `send_client_frame` helper (#19.2).
- **`ensure_git_repo`** — switch from `std::process::Command` + `std::fs::create_dir_all` to `tokio::process::Command` + `tokio::fs::create_dir_all` so the `async fn` no longer blocks a runtime worker on sync IO (#19.3). `tokio::fs::create_dir_all` is idempotent, so the manual `path.exists()` precheck is gone.
- **`ws probe-terminal --project-root`** — drop the fixed `/tmp/charon-probe` default. When the flag is omitted, allocate a fresh `tempfile::tempdir()` per invocation and let the `TempDir` guard remove it on exit. Explicit `--project-root <path>` still works for reuse (#15).

## Acceptance criteria

#19:
- [x] `cargo build --workspace` clean after deps removal.
- [x] `ensure_git_repo` body has no `std::process::Command` references.
- [ ] `doctor` and `ws probe-terminal` still pass after the refactors *(needs live daemon + nyxid; build/clippy/tests are clean locally)*.

#15:
- [x] Default path no longer collides between probe runs (each run gets `/tmp/.tmpXXXXXX`).
- [x] Existing `--project-root` flag still works for explicit reuse.
- [x] Probe still archives the workspace on success; the tempdir is cleaned by `TempDir` drop.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (33 passing)
- [x] `cargo fmt --all -- --check`
- [ ] manual `charon ws probe-terminal` against a live NyxID + daemon

🤖 Generated with [Claude Code](https://claude.com/claude-code)